### PR TITLE
chore: bump deps

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-yuki-stack",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "A CLI tool for scaffolding type-safe, full-stack TypeScript applications with best practices and customizable.",
   "keywords": [
     "cli",

--- a/cli/src/commands/init/create/base.ts
+++ b/cli/src/commands/init/create/base.ts
@@ -5,7 +5,7 @@ import type { ProjectOptions } from '@/commands/init/types'
 const versionMap = new Map<string, string>([
   ['npm', '11.4.0'],
   ['yarn', '1.22.22'],
-  ['pnpm', '10.11.0'],
+  ['pnpm', '10.12.0'],
   ['bun', '1.2.16'],
 ])
 

--- a/cli/templates/apps/react-router/package.json
+++ b/cli/templates/apps/react-router/package.json
@@ -18,18 +18,18 @@
     "@{{ name }}/ui": "workspace:*",
     "@{{ name }}/validators": "workspace:*",
     "@react-router/fs-routes": "^7.6.2",
-    "@react-router/node": "^7.5.3",
-    "@react-router/serve": "^7.5.3",
-    "isbot": "^5.1.27",
+    "@react-router/node": "^7.6.2",
+    "@react-router/serve": "^7.6.2",
+    "isbot": "^5.1.28",
     "react": "catalog:react",
     "react-dom": "catalog:react",
-    "react-router": "^7.5.3"
+    "react-router": "^7.6.2"
   },
   "devDependencies": {
     "@{{ name }}/eslint-config": "workspace:*",
     "@{{ name }}/prettier-config": "workspace:*",
     "@{{ name }}/tsconfig": "workspace:*",
-    "@react-router/dev": "^7.5.3",
+    "@react-router/dev": "^7.6.2",
     "@tailwindcss/vite": "^4.1.10",
     "@types/node": "catalog:",
     "@types/react": "catalog:react",
@@ -40,7 +40,7 @@
     "prettier": "catalog:",
     "tailwindcss": "^4.1.10",
     "typescript": "catalog:",
-    "vite": "^6.3.3",
+    "vite": "^6.3.5",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/cli/templates/apps/tanstack-start/package.json
+++ b/cli/templates/apps/tanstack-start/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "@{{ name }}/ui": "workspace:*",
     "@{{ name }}/validators": "workspace:*",
-    "@tanstack/react-router": "^1.121.21",
-    "@tanstack/react-start": "^1.121.23",
+    "@tanstack/react-router": "^1.121.27",
+    "@tanstack/react-start": "^1.121.31",
     "react": "catalog:react",
     "react-dom": "catalog:react"
   },
@@ -35,7 +35,7 @@
     "prettier": "catalog:",
     "tailwindcss": "^4.1.10",
     "typescript": "catalog:",
-    "vite": "^6.3.3",
+    "vite": "^6.3.5",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/cli/templates/package.json
+++ b/cli/templates/package.json
@@ -26,20 +26,21 @@
   "prettier": "@{{ name }}/prettier-config",
   "scripts": {
     "build": "turbo run build",
-    "bump-deps": "bunx npm-check-updates --deep -u && bun install",
+    "bump-deps": "{{ pkme }} npm-check-updates --deep -u && {{ pkm }} install",
     "clean": "git clean -xdf node_modules",
     "clean:workspaces": "turbo run clean",
     "dev": "turbo dev --continue",
     "format": "turbo run format --continue -- --cache --cache-location .cache/prettiercache",
     "format:fix": "turbo run format --continue -- --write --cache --cache-location .cache/prettiercache",
-    "postinstall": "bun run lint:ws",
+    "postinstall": "{{ pkm }} run lint:ws",
     "lint": "turbo run lint --continue -- --cache --cache-location .cache/eslintcache",
     "lint:fix": "turbo run lint --continue -- --fix --cache --cache-location .cache/eslintcache",
-    "lint:ws": "bunx sherif@latest",
+    "lint:ws": "{{ pkme }} sherif@latest",
     "typecheck": "turbo run typecheck"
   },
   "devDependencies": {
     "@{{ name }}/prettier-config": "workspace:*",
+    "@{{ name }}/tsconfig": "workspace:*",
     "@turbo/gen": "^2.5.4",
     "turbo": "^2.5.4"
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package versions for the CLI tool and templates, including dependencies for React Router, TanStack Start, and Vite.
  - Increased the minimum supported pnpm version for project initialization.
  - Enhanced package.json templates to use templated package manager commands instead of hardcoded ones.
  - Added a new devDependency for TypeScript configuration in the template package.json files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->