### PR TITLE
feat: remove radix-ui

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-yuki-stack",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "A CLI tool for scaffolding type-safe, full-stack TypeScript applications with best practices and customizable.",
   "keywords": [
     "cli",

--- a/cli/templates/packages/ui/package.json
+++ b/cli/templates/packages/ui/package.json
@@ -28,11 +28,11 @@
   },
   "prettier": "@{{ name }}/prettier-config",
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.519.0",
     "next-themes": "^0.4.6",
-    "radix-ui": "^1.4.2",
     "react": "catalog:react",
     "tailwind-merge": "^3.3.1"
   },

--- a/cli/templates/packages/ui/src/components/button.tsx
+++ b/cli/templates/packages/ui/src/components/button.tsx
@@ -1,7 +1,7 @@
 import type { VariantProps } from 'class-variance-authority'
 import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
 import { cva } from 'class-variance-authority'
-import { Slot } from 'radix-ui'
 
 import { cn } from '@{{ name }}/ui'
 
@@ -46,7 +46,7 @@ function Button({
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean
   }) {
-  const Comp = asChild ? Slot.Root : 'button'
+  const Comp = asChild ? Slot : 'button'
 
   return (
     <Comp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CLI tool version to 0.1.13.
	- Updated UI package dependencies by replacing "radix-ui" with "@radix-ui/react-slot" for improved compatibility.
- **Bug Fixes**
	- Improved the Button component to use the correct Slot component, ensuring more reliable rendering when using the asChild option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->