### PR TITLE
fix: vercel env

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-yuki-stack",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "A CLI tool for scaffolding type-safe, full-stack TypeScript applications with best practices and customizable.",
   "keywords": [
     "cli",

--- a/cli/templates/packages/validators/src/env.ts
+++ b/cli/templates/packages/validators/src/env.ts
@@ -5,7 +5,7 @@ export const env = createEnv({
     NODE_ENV: z._default(z.enum(['development', 'production', 'test']), 'development'),
 
     // Vercel environment variables
-    VERCEL: z.optional(z.boolean()),
+    VERCEL: z.optional(z.string()),
     VERCEL_ENV: z.optional(z.enum(['production', 'preview', 'development'])),
     VERCEL_URL: z.optional(z.string()),
     VERCEL_PROJECT_PRODUCTION_URL: z.optional(z.string()),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the CLI tool version to 0.1.14.

- **Refactor**
  - Changed the expected type for the VERCEL environment variable from an optional boolean to an optional string in environment validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->